### PR TITLE
Add new theme

### DIFF
--- a/theme
+++ b/theme
@@ -14,6 +14,7 @@
   "basnijholt/lovelace-ios-light-mode-theme",
   "basnijholt/lovelace-ios-themes",
   "bbbenji/synthwave-hass",
+  "brezlord/BrezNET-iOS",
   "catppuccin/home-assistant",
   "chaptergy/noctis-grey",
   "coltondick/nordic-theme-main",


### PR DESCRIPTION
### Checklist

Before you submit a pull request, please make sure you have to following:

- [X] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).

- [X] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.

- [X] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.

- [X] The actions are passing without any disabled checks in my repository.

- [x] I've added a link to the action run on my repository below in the links section.

- [X] I've created a new release of the repository after the validation actions were run successfully.

### Links

Link to current release: https://github.com/brezlord/BrezNET-iOS
Link to successful HACS action (without the ignore key): https://github.com/brezlord/BrezNET-iOS/actions/runs/7519156925

### Description

Home Assistant theme based on Apple iOS colours.

This theme has been designed to work on the Samsung Galaxy Tab A (2019, 10.1") [SM-T510] as a wall mounted display for Home Assistant. The theme displays equally as good on mobile devices.

The theme is based on Apple Colors from - https://developer.apple.com/design/human-interface-guidelines/color

Clolor palette used iOS, iPadOS and system grey colors.